### PR TITLE
tl_detector based on tensorflow model

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,13 @@ This is the project repo for the final project of the Udacity Self-Driving Car N
 
 Please use **one** of the two installation options, either native **or** docker installation.
 
+## Getting started
+
+-  Install the needed tensorflow models in the tl_detector module
+    `ros/src/tl_detector/sim_model.pb` and `ros/src/tl_detector/carla_model.pb`
+- Alternatively start using the launch configuration that doesn't use detection
+    `cd ros && roslaunch launch/styx-no-tf.launch`
+
 ### Native Installation
 https://www.jetbrains.com/help/clion/attaching-to-local-process.html
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,5 +6,5 @@ numpy==1.13.1
 Pillow==2.2.1
 scipy==0.19.1
 keras==2.0.8
-tensorflow==1.3.0
+tensorflow-gpu==1.3.0
 h5py==2.6.0

--- a/ros/launch/styx-no-tf.launch
+++ b/ros/launch/styx-no-tf.launch
@@ -1,0 +1,23 @@
+<?xml version="1.0"?>
+<launch>
+    <!-- Simulator Bridge -->
+    <include file="$(find styx)/launch/server.launch" />
+
+    <!--DBW Node -->
+    <include file="$(find twist_controller)/launch/dbw_sim.launch"/>
+
+    <!--Waypoint Loader -->
+    <include file="$(find waypoint_loader)/launch/waypoint_loader.launch"/>
+
+    <!--Waypoint Follower Node -->
+    <include file="$(find waypoint_follower)/launch/pure_pursuit.launch"/>
+
+    <!--Waypoint Updater Node -->
+    <include file="$(find waypoint_updater)/launch/waypoint_updater.launch"/>
+
+    <!--Traffic Light Detector Node -->
+    <include file="$(find tl_detector)/launch/tl_detector_sim_no_tf.launch"/>
+
+    <!--Traffic Light Locations and Camera Config -->
+    <param name="traffic_light_config" textfile="$(find tl_detector)/sim_traffic_light_config.yaml" />
+</launch>

--- a/ros/src/tl_detector/CMakeLists.txt
+++ b/ros/src/tl_detector/CMakeLists.txt
@@ -200,4 +200,9 @@ include_directories(
 # endif()
 
 ## Add folders to be run by python nosetests
-# catkin_add_nosetests(test)
+#catkin_add_nosetests(test)
+
+if (CATKIN_ENABLE_TESTING)
+    find_package(rostest REQUIRED)
+    add_rostest(test/tl_detector.test)
+endif()

--- a/ros/src/tl_detector/launch/tl_detector.launch
+++ b/ros/src/tl_detector/launch/tl_detector.launch
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <launch>
     <!--Traffic Light tf model -->
-    <param name="traffic_light_model" binfile="$(find tl_detector)/sim_model.pb" />
+    <param name="traffic_light_model" value="$(find tl_detector)/sim_model.pb" />
 
     <node pkg="tl_detector" type="tl_detector.py" name="tl_detector" output="screen" cwd="node"/>
 </launch>

--- a/ros/src/tl_detector/launch/tl_detector.launch
+++ b/ros/src/tl_detector/launch/tl_detector.launch
@@ -1,4 +1,7 @@
 <?xml version="1.0"?>
 <launch>
+    <!--Traffic Light tf model -->
+    <param name="traffic_light_model" binfile="$(find tl_detector)/sim_model.pb" />
+
     <node pkg="tl_detector" type="tl_detector.py" name="tl_detector" output="screen" cwd="node"/>
 </launch>

--- a/ros/src/tl_detector/launch/tl_detector_sim_no_tf.launch
+++ b/ros/src/tl_detector/launch/tl_detector_sim_no_tf.launch
@@ -1,0 +1,7 @@
+<?xml version="1.0"?>
+<launch>
+    <!--Traffic Light tf model -->
+    <param name="traffic_light_model" value="" />
+
+    <node pkg="tl_detector" type="tl_detector.py" name="tl_detector" output="screen" cwd="node"/>
+</launch>

--- a/ros/src/tl_detector/launch/tl_detector_site.launch
+++ b/ros/src/tl_detector/launch/tl_detector_site.launch
@@ -1,5 +1,8 @@
 <?xml version="1.0"?>
 <launch>
+    <!--Traffic Light tf model -->
+    <param name="traffic_light_model" value="$(find tl_detector)/carla_model.pb" />
+
     <node pkg="tl_detector" type="tl_detector.py" name="tl_detector" output="screen" cwd="node"/>
     <node pkg="tl_detector" type="light_publisher.py" name="light_publisher" output="screen" cwd="node"/>
 </launch>

--- a/ros/src/tl_detector/light_classification/tl_classifier.py
+++ b/ros/src/tl_detector/light_classification/tl_classifier.py
@@ -2,6 +2,8 @@ from styx_msgs.msg import TrafficLight
 
 import rospy
 import tensorflow as tf
+import numpy as np
+import time
 
 
 class TLClassifier(object):
@@ -10,8 +12,12 @@ class TLClassifier(object):
         rospy.loginfo("Loading model file: %s", model_file)
         self.detection_graph = self.load_graph(model_file)
         self.session = tf.Session(graph=self.detection_graph)
-        rospy.loginfo("Model loaded")git
-        pass
+        rospy.loginfo("Model loaded")
+
+        self.labelmap = {1: TrafficLight.GREEN,
+                         2: TrafficLight.RED,
+                         3: TrafficLight.YELLOW,
+                         4: TrafficLight.UNKNOWN}
 
     def load_graph(self, model_file):
         detection_graph = tf.Graph()
@@ -26,6 +32,11 @@ class TLClassifier(object):
 
         return detection_graph
 
+    def load_image_into_numpy_array(self, image):
+        (im_width, im_height) = image.size
+        return np.array(image.getdata()).reshape((im_height, im_width, 3)).astype(np.uint8)
+
+
     def get_classification(self, image):
         """Determines the color of the traffic light in the image
 
@@ -37,7 +48,7 @@ class TLClassifier(object):
 
         """
 
-        print("Starting detection")
+        rospy.loginfo("Starting detection")
         detection_graph = self.detection_graph
         # with detection_graph.as_default():
         #     with tf.Session(graph=detection_graph) as sess:
@@ -53,5 +64,26 @@ class TLClassifier(object):
         detection_classes = detection_graph.get_tensor_by_name('detection_classes:0')
         num_detections = detection_graph.get_tensor_by_name('num_detections:0')
 
-        #TODO implement light color prediction
-        return TrafficLight.UNKNOWN
+        # the array based representation of the image will be used later in order to prepare the
+        # result image with boxes and labels on it.
+        image_np = image
+        # Expand dimensions since the model expects images to have shape: [1, None, None, 3]
+        image_np_expanded = np.expand_dims(image_np, axis=0)
+
+        time0 = time.time()
+
+        # Actual detection.
+        (boxes, scores, classes, num) = self.session.run(
+            [detection_boxes, detection_scores, detection_classes, num_detections],
+            feed_dict={image_tensor: image_np_expanded})
+
+        time1 = time.time()
+
+        rospy.loginfo("Detection in {}ms".format((time1 - time0) * 1000))
+        scores = np.squeeze(scores)
+        classes = np.squeeze(classes).astype(np.int32)
+
+        min_score_thresh = .50
+        combined = sorted([x for x in zip(classes, scores) if x[1] > min_score_thresh], key=lambda tup: tup[1])
+        rospy.loginfo("Sorted scores: %s", combined)
+        return self.labelmap[combined[-1][0]] if len(combined) > 1 else TrafficLight.UNKNOWN

--- a/ros/src/tl_detector/light_classification/tl_classifier.py
+++ b/ros/src/tl_detector/light_classification/tl_classifier.py
@@ -7,9 +7,10 @@ import tensorflow as tf
 class TLClassifier(object):
 
     def __init__(self, model_file):
-        rospy.loginfo("Loading model file: {}", model_file)
-        self.session = tf.Session()
+        rospy.loginfo("Loading model file: %s", model_file)
         self.detection_graph = self.load_graph(model_file)
+        self.session = tf.Session(graph=self.detection_graph)
+        rospy.loginfo("Model loaded")git
         pass
 
     def load_graph(self, model_file):
@@ -38,6 +39,8 @@ class TLClassifier(object):
 
         print("Starting detection")
         detection_graph = self.detection_graph
+        # with detection_graph.as_default():
+        #     with tf.Session(graph=detection_graph) as sess:
         # Definite input and output Tensors for detection_graph
         image_tensor = detection_graph.get_tensor_by_name('image_tensor:0')
 

--- a/ros/src/tl_detector/light_classification/tl_classifier.py
+++ b/ros/src/tl_detector/light_classification/tl_classifier.py
@@ -1,9 +1,29 @@
 from styx_msgs.msg import TrafficLight
 
+import rospy
+import tensorflow as tf
+
+
 class TLClassifier(object):
-    def __init__(self):
-        #TODO load classifier
+
+    def __init__(self, model_file):
+        rospy.loginfo("Loading model file: {}", model_file)
+        self.session = tf.Session()
+        self.detection_graph = self.load_graph(model_file)
         pass
+
+    def load_graph(self, model_file):
+        detection_graph = tf.Graph()
+
+        with detection_graph.as_default():
+            od_graph_def = tf.GraphDef()
+
+            with tf.gfile.GFile(model_file, 'rb') as fid:
+                serialized_graph = fid.read()
+                od_graph_def.ParseFromString(serialized_graph)
+                tf.import_graph_def(od_graph_def, name='')
+
+        return detection_graph
 
     def get_classification(self, image):
         """Determines the color of the traffic light in the image
@@ -15,5 +35,20 @@ class TLClassifier(object):
             int: ID of traffic light color (specified in styx_msgs/TrafficLight)
 
         """
+
+        print("Starting detection")
+        detection_graph = self.detection_graph
+        # Definite input and output Tensors for detection_graph
+        image_tensor = detection_graph.get_tensor_by_name('image_tensor:0')
+
+        # Each box represents a part of the image where a particular object was detected.
+        detection_boxes = detection_graph.get_tensor_by_name('detection_boxes:0')
+
+        # Each score represent how level of confidence for each of the objects.
+        # Score is shown on the result image, together with the class label.
+        detection_scores = detection_graph.get_tensor_by_name('detection_scores:0')
+        detection_classes = detection_graph.get_tensor_by_name('detection_classes:0')
+        num_detections = detection_graph.get_tensor_by_name('num_detections:0')
+
         #TODO implement light color prediction
         return TrafficLight.UNKNOWN

--- a/ros/src/tl_detector/package.xml
+++ b/ros/src/tl_detector/package.xml
@@ -47,6 +47,7 @@
   <build_depend>std_msgs</build_depend>
   <build_depend>styx_msgs</build_depend>
   <build_depend>waypoint_updater</build_depend>
+  <build_depend>rostest</build_depend>
   <run_depend>geometry_msgs</run_depend>
   <run_depend>roscpp</run_depend>
   <run_depend>rospy</run_depend>

--- a/ros/src/tl_detector/test/test_tl_detector.py
+++ b/ros/src/tl_detector/test/test_tl_detector.py
@@ -1,0 +1,24 @@
+#!/usr/bin/python
+PKG = 'tl_detector'
+NAME = 'test_tl_detector'
+
+import sys
+import time
+import unittest
+import rospy
+
+
+class TestTLDetector(unittest.TestCase):
+    def __init__(self, *args):
+        super(TestTLDetector, self).__init__(*args)
+
+    def setUp(self):
+        rospy.init_node(NAME)
+
+    def test_simple(self):
+        pass
+
+
+if __name__ == '__main__':
+    import rostest
+    rostest.rosrun(PKG, NAME, TestTLDetector)

--- a/ros/src/tl_detector/test/tl_detector.test
+++ b/ros/src/tl_detector/test/tl_detector.test
@@ -1,0 +1,5 @@
+<?xml version="1.0"?>
+<launch>
+    <include file = "$(find tl_detector)/launch/tl_detector.launch" />
+    <test pkg="tl_detector" type="test/test_tl_detector.py" test-name="test_tl_detector"/>
+</launch>

--- a/ros/src/tl_detector/tl_detector.py
+++ b/ros/src/tl_detector/tl_detector.py
@@ -11,8 +11,10 @@ import tf
 import cv2
 import yaml
 from scipy.spatial import KDTree
+import time
 
 STATE_COUNT_THRESHOLD = 3
+INTERVAL_THRESHOLD_MS = 150
 
 
 class TLDetector(object):
@@ -25,6 +27,7 @@ class TLDetector(object):
         self.waypoint_tree = None
         self.camera_image = None
         self.lights = []
+        self.last_processed_time = -1
 
         sub1 = rospy.Subscriber('/current_pose', PoseStamped, self.pose_cb)
         sub2 = rospy.Subscriber('/base_waypoints', Lane, self.waypoints_cb)
@@ -81,11 +84,12 @@ class TLDetector(object):
 
         """
 
-        # if self.image_ctr < 3:
-        #     self.image_ctr += 1
-        #     return
-        # else:
-        #     self.image_ctr = 0
+        time_start = time.time()
+        if self.last_processed_time > 0 and (time_start - self.last_processed_time) * 1000 < INTERVAL_THRESHOLD_MS:
+            rospy.loginfo("Skipping frame")
+            return
+
+        self.last_processed_time = time_start
 
         rospy.loginfo('Processing image. State %s, last %s, count %s', self.state, self.last_state, self.state_count)
 

--- a/ros/src/tl_detector/tl_detector.py
+++ b/ros/src/tl_detector/tl_detector.py
@@ -45,7 +45,7 @@ class TLDetector(object):
         self.upcoming_red_light_pub = rospy.Publisher('/traffic_waypoint', Int32, queue_size=1)
 
         model_file = rospy.get_param("/traffic_light_model")
-        rospy.loginfo("Using tl model: {}", model_file)
+        rospy.loginfo("Using tl model: %s", model_file)
 
         self.bridge = CvBridge()
         self.light_classifier = TLClassifier(model_file)

--- a/ros/src/tl_detector/tl_detector.py
+++ b/ros/src/tl_detector/tl_detector.py
@@ -136,7 +136,7 @@ class TLDetector(object):
 
         """
         # TODO
-        return light.state
+        # return light.state
 
         if (not self.has_image):
             self.prev_light_loc = None

--- a/ros/src/tl_detector/tl_detector.py
+++ b/ros/src/tl_detector/tl_detector.py
@@ -44,8 +44,11 @@ class TLDetector(object):
 
         self.upcoming_red_light_pub = rospy.Publisher('/traffic_waypoint', Int32, queue_size=1)
 
+        model_file = rospy.get_param("/traffic_light_model")
+        rospy.loginfo("Using tl model: {}", model_file)
+
         self.bridge = CvBridge()
-        self.light_classifier = TLClassifier()
+        self.light_classifier = TLClassifier(model_file)
         self.listener = tf.TransformListener()
 
         self.state = TrafficLight.UNKNOWN


### PR DESCRIPTION
Adds the detection code to the tl_detector to enable detection based on the trained models from #12.

TODO:
- [x] Update configuration to use GPU
- [x] Add code for inference
- [x] Add launch configuration for simulator
- [x] Add launch configuration for carla
- [x] Add launch configuration for simulator without TF model (handy when no GPU / model is available)

Closes #16 